### PR TITLE
docs(adr): fix ADR-0056 duplicate and navigation mismatches

### DIFF
--- a/adr/adr-0060-database-architecture-and-naming-convention.md
+++ b/adr/adr-0060-database-architecture-and-naming-convention.md
@@ -1,4 +1,4 @@
-# 56. Database Architecture and Naming Convention
+# 60. Database Architecture and Naming Convention
 
 Date: 2025-11-18
 

--- a/docs/architecture/adr-0060-database-architecture-and-naming-convention.mdx
+++ b/docs/architecture/adr-0060-database-architecture-and-naming-convention.mdx
@@ -1,16 +1,16 @@
 ---
-title: 'ADR-0056: Database Architecture and Naming Convention'
+title: 'ADR-0060: Database Architecture and Naming Convention'
 description: Standardizes multi-database PostgreSQL architecture with consistent naming
   conventions across development, test, staging, and production environments for GDPR,
   OpenFGA, and Keycloak services
 icon: database
 contentType: reference
-seoTitle: 'ADR-0056: Database Architecture... - MCP Server LangGraph'
+seoTitle: 'ADR-0060: Database Architecture... - MCP Server LangGraph'
 seoDescription: Standardizes multi-database PostgreSQL architecture with consistent
   naming conventions across development, test, staging, and production environments
   for GDP.
 keywords:
-- adr-0056
+- adr-0060
 - database
 - architecture
 - naming
@@ -21,7 +21,7 @@ keywords:
 - consistent
 - conventions
 ---
-# 56. Database Architecture and Naming Convention
+# 60. Database Architecture and Naming Convention
 
 Date: 2025-11-18
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -409,10 +409,10 @@
               "architecture/adr-0053-ci-cd-failure-prevention-framework",
               "architecture/adr-0054-pod-failure-prevention-framework",
               "architecture/adr-0055-diagram-visualization-standards",
-              "architecture/adr-0056-database-architecture-and-naming-convention",
-              "architecture/adr-0057-asyncmock-configuration-prevention",
-              "architecture/adr-0058-circuit-breaker-decorator-closure-isolation",
-              "architecture/adr-0059-pytest-xdist-state-pollution-prevention"
+              "architecture/adr-0056-asyncmock-configuration-prevention",
+              "architecture/adr-0057-circuit-breaker-decorator-closure-isolation",
+              "architecture/adr-0058-pytest-xdist-state-pollution-prevention",
+              "architecture/adr-0060-database-architecture-and-naming-convention"
             ]
           },
           {


### PR DESCRIPTION
## Summary

Fixed critical documentation issues identified in comprehensive audit:
- ADR-0056 numbering collision (renumbered database-architecture to ADR-0060)
- Navigation reference mismatches in docs/docs.json

## Critical Fixes

### 1. ADR Numbering Collision ✅
- **Issue**: Duplicate ADR-0056 existed (asyncmock-configuration vs database-architecture)
- **Fix**: Renumbered database-architecture ADR from 0056 → 0060
- **Files**: Updated both `.md` and `.mdx` files + frontmatter

### 2. Navigation Reference Mismatches ✅
- **Issue**: 3 orphaned files + 3 broken navigation references
- **Fix**: Updated `docs/docs.json` navigation sequence
  - ADR-0057 → ADR-0056 (asyncmock-configuration-prevention)
  - ADR-0058 → ADR-0057 (circuit-breaker-decorator-closure-isolation)
  - ADR-0059 → ADR-0058 (pytest-xdist-state-pollution-prevention)
  - Added ADR-0060 (database-architecture-and-naming-convention)

## Validation Results

✅ **Mintlify CLI**: no broken links found
✅ **ADR Sync**: 59/59 ADRs synchronized
✅ **MDX Extensions**: 254/254 files valid
✅ **Frontmatter**: 100% compliance
✅ **Pre-commit Hooks**: all documentation hooks passed

## Files Changed

- `adr/adr-0056-*` → `adr/adr-0060-database-architecture-and-naming-convention.md`
- `docs/architecture/adr-0056-*` → `adr-0060-database-architecture-and-naming-convention.mdx`
- `docs/docs.json` (navigation sequence updates)

**Total**: 3 files, 9 insertions(+), 9 deletions(-)

## Test Plan

- [x] Run `make docs-validate` - ✅ Passed
- [x] Run `cd docs && npx mintlify broken-links` - ✅ No broken links
- [x] Verify ADR synchronization - ✅ 59/59 synced
- [x] Run pre-commit hooks on changed files - ✅ All passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)