### PR TITLE
feat(ci): add Vertex AI integration tests with Workload Identity Federation

### DIFF
--- a/.github/SECRETS.md
+++ b/.github/SECRETS.md
@@ -89,6 +89,28 @@ gcloud iam service-accounts add-iam-policy-binding \
 - `.github/workflows/gcp-drift-detection.yaml` (3 jobs)
 - All jobs have repository check: `if: github.repository == 'vishnu2kmohan/mcp-server-langgraph'`
 
+#### Vertex AI Integration Tests (CI)
+
+| Secret Name | Description | Setup Instructions |
+|-------------|-------------|-------------------|
+| `GCP_WIF_PROVIDER` | Workload Identity Pool Provider (same as production) | See above |
+| `GCP_VERTEX_AI_SA_EMAIL` | Vertex AI CI service account | `github-actions-vertex-ai@PROJECT_ID.iam.gserviceaccount.com` |
+
+**Used By**:
+- `.github/workflows/integration-tests.yaml` (vertex-ai-tests job)
+- Job has repository check: `if: github.repository == 'vishnu2kmohan/mcp-server-langgraph'`
+
+**Required IAM Roles**:
+- `roles/aiplatform.user` - Access Vertex AI APIs (Claude + Gemini)
+- `roles/serviceusage.serviceUsageConsumer` - Consume GCP services
+
+**Setup Steps**:
+```bash
+# Service account is created by Terraform (terraform/environments/gcp-staging-wif-only)
+# After terraform apply, add the secret:
+gh secret set GCP_VERTEX_AI_SA_EMAIL --body "github-actions-vertex-ai@PROJECT_ID.iam.gserviceaccount.com"
+```
+
 ### Package Publishing
 
 #### PyPI
@@ -370,5 +392,5 @@ For questions or issues with secrets configuration:
 3. Check GCP audit logs for authentication issues
 4. Contact the engineering team
 
-**Last Review**: 2025-11-07
-**Next Review**: 2025-12-07 (monthly)
+**Last Review**: 2025-12-01
+**Next Review**: 2026-01-01 (monthly)

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -50,6 +50,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write  # Required for Workload Identity Federation with Vertex AI
 
 env:
   # Prevent BlockingIOError when capturing large test output
@@ -218,3 +219,62 @@ jobs:
         MINIMUM_GREEN: 80
         MINIMUM_ORANGE: 70
       continue-on-error: true  # Don't fail PR if coverage comment fails
+
+  # ============================================================================
+  # Vertex AI Integration Tests (Claude + Gemini via Workload Identity Federation)
+  # ============================================================================
+  # These tests require GCP Workload Identity Federation to access Vertex AI APIs.
+  # They only run on the main repository (not forks) due to secret requirements.
+  # Uses keyless authentication via google-github-actions/auth@v3.
+
+  vertex-ai-tests:
+    name: Vertex AI Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Only run on main repository (forks don't have access to GCP secrets)
+    if: github.repository == 'vishnu2kmohan/mcp-server-langgraph'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Authenticate to Google Cloud (Workload Identity Federation)
+      uses: google-github-actions/auth@v3
+      with:
+        workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+        service_account: ${{ secrets.GCP_VERTEX_AI_SA_EMAIL }}
+        token_format: access_token
+
+    - name: Set up Python and dependencies
+      uses: ./.github/actions/setup-python-deps
+      with:
+        python-version: '3.12'
+        extras: 'dev'
+        cache-key-prefix: 'vertex-ai-tests'
+
+    - name: Run Vertex AI Integration Tests
+      env:
+        # Vertex AI configuration for Anthropic Claude models
+        VERTEX_PROJECT: ${{ vars.GCP_PROJECT_ID }}
+        CLOUD_ML_REGION: us-east5
+        ANTHROPIC_VERTEX_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+        # Vertex AI configuration for Google Gemini models
+        GOOGLE_CLOUD_PROJECT: ${{ vars.GCP_PROJECT_ID }}
+        GOOGLE_CLOUD_LOCATION: us-central1
+        # Enable Vertex AI mode (uses WIF instead of API keys)
+        CLAUDE_CODE_USE_VERTEX: "1"
+      run: |
+        echo "🤖 Running Vertex AI integration tests..."
+        echo "   Project: $VERTEX_PROJECT"
+        echo "   Claude Region: $CLOUD_ML_REGION"
+        echo "   Gemini Region: $GOOGLE_CLOUD_LOCATION"
+
+        # Run tests with vertex_ai marker
+        uv run --frozen pytest tests/integration/test_vertex_ai_anthropic.py \
+          tests/integration/test_vertex_ai_google.py \
+          tests/integration/test_vertex_ai_auth_methods.py \
+          -v --tb=short \
+          -x \
+          --timeout=120
+
+        echo "✅ Vertex AI tests completed"

--- a/terraform/environments/gcp-staging-wif-only/main.tf
+++ b/terraform/environments/gcp-staging-wif-only/main.tf
@@ -110,5 +110,22 @@ module "github_actions_wif" {
         "roles/logging.viewer",
       ]
     }
+
+    # Vertex AI CI - access to Vertex AI for running integration tests with LLMs
+    # Used by: .github/workflows/integration-tests.yaml (vertex_ai job)
+    # Permissions: Vertex AI access for Claude (Anthropic) and Gemini (Google) models
+    vertex_ai_ci = {
+      account_id        = "github-actions-vertex-ai"
+      display_name      = "GitHub Actions - Vertex AI CI"
+      description       = "Service account for CI integration tests using Vertex AI (Claude + Gemini)"
+      repository_filter = "mcp-server-langgraph"
+
+      project_roles = [
+        # Vertex AI model invocation (required for Claude and Gemini API calls)
+        "roles/aiplatform.user",
+        # Service usage consumer (required for API access)
+        "roles/serviceusage.serviceUsageConsumer",
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Add CI support for running Vertex AI integration tests (Claude + Gemini) using Google Cloud Workload Identity Federation for keyless authentication
- Close stale GitHub issues after validation

## Changes

### Vertex AI CI Setup
- Add `vertex_ai_ci` service account in Terraform with `roles/aiplatform.user`
- Add `vertex-ai-tests` job to integration-tests.yaml workflow
- Configure WIF authentication for both Claude (us-east5) and Gemini (us-central1)
- Document `GCP_VERTEX_AI_SA_EMAIL` secret in SECRETS.md

### GitHub Issues Triaged
Closed 6 stale/resolved issues:
- #130 - Skipped tests (all expected environment-gated skips)
- #116 - Broken docs links (resolved)
- #115 - Duplicate of #130
- #82 - Doc validation failed (resolved)
- #105 - CI infrastructure broken (resolved - all tests passing)
- #83 - pytest-xdist isolation (fixed - tests pass with `-n auto`)

Remaining 6 issues are low-priority documentation TODOs (#75-80).

## Test plan

- [x] Pre-push hooks pass locally
- [ ] CI workflows pass
- [ ] After merge: Run `terraform apply` and add `GCP_VERTEX_AI_SA_EMAIL` secret

## Deployment Steps (Post-Merge)

```bash
# 1. Apply Terraform to create the service account
cd terraform/environments/gcp-staging-wif-only
terraform apply

# 2. Add the GitHub secret
gh secret set GCP_VERTEX_AI_SA_EMAIL \
  --body "github-actions-vertex-ai@vishnu-sandbox-20250310.iam.gserviceaccount.com"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)