### PR TITLE
fix(kustomize): switch preview-gke to GHCR :preview tag

### DIFF
--- a/deployments/overlays/preview-gke/kustomization.yaml
+++ b/deployments/overlays/preview-gke/kustomization.yaml
@@ -242,18 +242,11 @@ patches:
       name: qdrant
 
 # Image configuration
-# For preview-gke: Use GCR (Google Container Registry) for the main app (TEMPORARY)
-# GHCR image was broken - use GCR until CI/CD change is merged to main
-# Once merged: CI creates ghcr.io/vishnu2kmohan/mcp-server-langgraph:preview on main pushes
-# Then update this to use GHCR: newName: ghcr.io/vishnu2kmohan/mcp-server-langgraph, newTag: preview
-# Other dependencies (Keycloak, OpenFGA, etc.) continue to use GHCR mirrors
+# For preview-gke: Use GHCR with :preview tag (built by CI on main branch merges)
 images:
-  # Main application image - use GCR for preview-gke (TEMPORARY - switch to GHCR :preview after CI merge)
-  # Built locally and pushed to: gcr.io/vishnu-sandbox-20250310/mcp-server-langgraph:latest
-  # FIXED: CI now creates :preview tag on main branch pushes (see .github/workflows/ci.yaml:1025-1033)
+  # Main application image - GHCR :preview tag (built by CI workflow)
   - name: ghcr.io/vishnu2kmohan/mcp-server-langgraph
-    newName: gcr.io/vishnu-sandbox-20250310/mcp-server-langgraph
-    newTag: latest
+    newTag: preview
 
   # Keycloak optimized image (pre-built with kc.sh build)
   # This image eliminates runtime Quarkus augmentation that causes ReadOnlyFileSystemException

--- a/tests/deployment/test_kustomize_build.py
+++ b/tests/deployment/test_kustomize_build.py
@@ -291,18 +291,10 @@ def test_container_images_have_tags(overlay_dir: Path):
         for container in containers:
             image = container.get("image", "")
 
-            # TEMPORARY: Allow GCR workaround until GHCR :preview tag is created
-            # This will be removed after CI fix is merged and kustomization.yaml
-            # is updated to use: newName: ghcr.io/vishnu2kmohan/mcp-server-langgraph, newTag: preview
-            # TODO: Remove this after switching to GHCR :preview tag
-            ALLOWED_LATEST_IMAGES = [
-                "gcr.io/vishnu-sandbox-20250310/mcp-server-langgraph:latest",
-            ]
-
             # Must have a tag
             if ":" not in image:
                 issues.append(f"{kind}/{name} container '{container.get('name')}' uses image without tag: {image}")
-            elif image.endswith(":latest") and image not in ALLOWED_LATEST_IMAGES:
+            elif image.endswith(":latest"):
                 issues.append(f"{kind}/{name} container '{container.get('name')}' uses :latest tag: {image}")
 
     assert not issues, "Container image issues:\n" + "\n".join(issues)

--- a/tests/kubernetes/test_kustomize_preview_gke.py
+++ b/tests/kubernetes/test_kustomize_preview_gke.py
@@ -305,12 +305,6 @@ class TestKustomizePreviewGKE:
             "preview-latest",
             "dev-latest",
             "development-latest",
-            # TEMPORARY: Allow GCR workaround until GHCR :preview tag is created
-            # This will be removed after CI fix is merged and kustomization.yaml
-            # is updated to use: newName: ghcr.io/vishnu2kmohan/mcp-server-langgraph, newTag: preview
-            # See: https://github.com/vishnu2kmohan/mcp-server-langgraph/pull/XXX
-            # TODO: Remove this after switching to GHCR :preview tag
-            "gcr.io/vishnu-sandbox-20250310/mcp-server-langgraph:latest",
         ]
 
         violations = []


### PR DESCRIPTION
## Summary
- Switch preview-gke Kustomize overlay to use GHCR `:preview` tag instead of temporary GCR workaround
- Remove GCR exceptions from test validation files
- CI now successfully pushes `:preview` tag to GHCR (per commit 4ea3cbc1)

## Changes
- `deployments/overlays/preview-gke/kustomization.yaml`: Use `ghcr.io/vishnu2kmohan/mcp-server-langgraph:preview` (CI-built)
- `tests/deployment/test_kustomize_build.py`: Remove temporary GCR workaround
- `tests/kubernetes/test_kustomize_preview_gke.py`: Remove GCR exception from ALLOWED_LATEST_PATTERNS

## Test plan
- [x] Verified Kustomize build produces correct image: `ghcr.io/vishnu2kmohan/mcp-server-langgraph:preview`
- [x] Ran `test_container_images_have_tags` - PASSED
- [x] Ran `test_all_deployments_have_valid_images` - PASSED
- [ ] CI pipeline validates all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)