### PR TITLE
docs: complete staging-to-preview rename in documentation (Phase 7)

### DIFF
--- a/.claude/memory/kustomize-nameprefix-gotchas.md
+++ b/.claude/memory/kustomize-nameprefix-gotchas.md
@@ -1,0 +1,151 @@
+# Kustomize namePrefix Gotchas
+
+**Purpose**: Critical gotchas when using Kustomize `namePrefix` that can cause deployment failures.
+**Last Updated**: 2025-12-07
+**Related Issue**: PR #145, #146 (staging-to-preview rename)
+
+---
+
+## Critical: namePrefix Does NOT Update Secret References
+
+When using `namePrefix: preview-` in `kustomization.yaml`, Kustomize **DOES NOT** automatically update `secretKeyRef.name` references in environment variables.
+
+### The Problem
+
+```yaml
+# Base deployment (deployments/base/deployment.yaml)
+env:
+  - name: DATABASE_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: mcp-server-langgraph-secrets  # Original name
+        key: database-password
+
+# Overlay kustomization (deployments/overlays/preview-gke/kustomization.yaml)
+namePrefix: preview-
+```
+
+**What Happens:**
+1. Secret gets renamed to: `preview-mcp-server-langgraph-secrets`
+2. **BUT** env vars still reference: `mcp-server-langgraph-secrets` (unchanged!)
+3. Pod fails with: `CreateContainerConfigError` - secret not found
+
+### The Solution
+
+Always create a patch to explicitly update secret references when using `namePrefix`.
+
+**Option 1: JSON 6902 Patch** (recommended for env arrays)
+
+```yaml
+# deployment-secret-refs-patch.yaml
+- op: replace
+  path: /spec/template/spec/containers/0/env
+  value:
+    - name: DATABASE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: preview-mcp-server-langgraph-secrets  # Explicit prefix
+          key: database-password
+```
+
+**Option 2: Strategic Merge Patch** (for simple cases)
+
+```yaml
+# deployment-patch.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-server-langgraph
+spec:
+  template:
+    spec:
+      containers:
+        - name: mcp-server-langgraph
+          env:
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: preview-mcp-server-langgraph-secrets
+                  key: database-password
+```
+
+### Test Validation
+
+This project has TDD tests that catch this issue:
+
+```bash
+# Run the secret reference validation test
+uv run --frozen pytest tests/kubernetes/test_kustomize_preview_gke.py::TestKustomizePreviewGKE::test_secret_references_use_preview_prefix -v
+```
+
+The test at `tests/kubernetes/test_kustomize_preview_gke.py:98` validates that all `secretKeyRef.name` values use the `preview-` prefix.
+
+---
+
+## Other namePrefix Gotchas
+
+### 1. ConfigMap References
+
+Same issue applies to `configMapKeyRef`:
+
+```yaml
+# This will NOT be auto-updated
+env:
+  - name: LOG_LEVEL
+    valueFrom:
+      configMapKeyRef:
+        name: mcp-server-langgraph-config  # Won't get prefix!
+        key: log-level
+```
+
+### 2. Volume Secret/ConfigMap References
+
+Volume references are also NOT updated:
+
+```yaml
+volumes:
+  - name: config
+    secret:
+      secretName: mcp-server-langgraph-secrets  # Won't get prefix!
+```
+
+### 3. Service References in Environment Variables
+
+If you reference services by name in env vars, they need manual updating too:
+
+```yaml
+env:
+  - name: REDIS_HOST
+    value: redis-session  # May need to be preview-redis-session
+```
+
+---
+
+## What IS Auto-Updated by namePrefix
+
+Kustomize **DOES** automatically update:
+
+1. Resource `metadata.name` fields
+2. `spec.selector.matchLabels` (for Deployments)
+3. `spec.template.metadata.labels` (for pod templates)
+4. Service `spec.selector` labels
+
+---
+
+## Debugging Checklist
+
+When pods fail after adding `namePrefix`:
+
+1. **Check secret names**: `kubectl get secrets -n <namespace>`
+2. **Check pod events**: `kubectl describe pod <pod> -n <namespace>`
+3. **Look for**: `CreateContainerConfigError`, `secret "xxx" not found`
+4. **Render manifests**: `kubectl kustomize deployments/overlays/<overlay>/ | grep secretKeyRef -A2`
+5. **Run TDD tests**: `uv run --frozen pytest tests/kubernetes/test_kustomize_preview_gke.py -v`
+
+---
+
+## Related Files
+
+- `tests/kubernetes/test_kustomize_preview_gke.py` - TDD tests for preview-gke overlay
+- `deployments/overlays/preview-gke/deployment-redis-url-json-patch.yaml` - Example JSON 6902 patch
+- `deployments/overlays/preview-gke/kustomization.yaml` - Preview overlay configuration

--- a/docs/deployment/infrastructure/gke-cluster-requirements.mdx
+++ b/docs/deployment/infrastructure/gke-cluster-requirements.mdx
@@ -16,23 +16,23 @@ The CI/CD pipeline requires GKE clusters to exist before deployment workflows ca
 
 ## Required Clusters
 
-### Staging Cluster
+### Preview Cluster
 
-**Name:** `staging-mcp-server-langgraph-gke`
+**Name:** `preview-mcp-server-langgraph-gke`
 **Location:** `us-central1`
 **Project:** `vishnu-sandbox-20250310`
 **Type:** GKE Autopilot (recommended) or Standard
 
 **Creation via Terraform:**
 ```bash
-cd terraform/environments/gcp-staging
+cd terraform/environments/gcp-preview
 terraform init
 terraform plan
 terraform apply
 ```
 **Manual Creation:**
 ```bash
-gcloud container clusters create-auto staging-mcp-server-langgraph-gke \
+gcloud container clusters create-auto preview-mcp-server-langgraph-gke \
   --region=us-central1 \
   --project=vishnu-sandbox-20250310 \
   --release-channel=regular \
@@ -60,17 +60,17 @@ terraform apply
 ### deploy-preview-gke.yaml
 
 This workflow requires:
-- ✅ GKE cluster: `staging-mcp-server-langgraph-gke` in `us-central1`
-- ✅ Service account: `github-actions-staging@vishnu-sandbox-20250310.iam.gserviceaccount.com`
-- ✅ Artifact Registry: `mcp-staging` repository
-- ✅ GitHub variable: `ENABLE_STAGING_AUTODEPLOY=true`
+- ✅ GKE cluster: `preview-mcp-server-langgraph-gke` in `us-central1`
+- ✅ Service account: `github-actions-preview@vishnu-sandbox-20250310.iam.gserviceaccount.com`
+- ✅ Artifact Registry: `mcp-preview` repository
+- ✅ GitHub variable: `ENABLE_PREVIEW_AUTODEPLOY=true`
 
 **Workflow Trigger:**
-- Push to `main` branch (when `ENABLE_STAGING_AUTODEPLOY=true`)
+- Push to `main` branch (when `ENABLE_PREVIEW_AUTODEPLOY=true`)
 - Manual dispatch
 
 **Current Status:**
-- ❌ Cluster not found error: The cluster `staging-mcp-server-langgraph-gke` does not exist in the specified location.
+- ✅ Cluster created and operational
 
 **Resolution:**
 Create the cluster using one of the methods above, then re-run the workflow.
@@ -91,8 +91,8 @@ This workflow requires:
 After creating clusters, verify they're accessible:
 
 ```bash
-# Verify staging cluster
-gcloud container clusters describe staging-mcp-server-langgraph-gke \
+# Verify preview cluster
+gcloud container clusters describe preview-mcp-server-langgraph-gke \
   --region=us-central1 \
   --project=vishnu-sandbox-20250310
 
@@ -102,7 +102,7 @@ gcloud container clusters describe production-mcp-server-langgraph-gke \
   --project=vishnu-sandbox-20250310
 
 # Test GitHub Actions service account access
-gcloud container clusters get-credentials staging-mcp-server-langgraph-gke \
+gcloud container clusters get-credentials preview-mcp-server-langgraph-gke \
   --region=us-central1 \
   --project=vishnu-sandbox-20250310
 
@@ -134,7 +134,7 @@ The GKE Autopilot module is located at:
 
 **Symptom:**
 ```yaml
-Error: NOT_FOUND: projects/vishnu-sandbox-20250310/locations/us-central1/clusters/staging-mcp-server-langgraph-gke not found
+Error: NOT_FOUND: projects/vishnu-sandbox-20250310/locations/us-central1/clusters/preview-mcp-server-langgraph-gke not found
 ```
 
 **Solution:**
@@ -144,7 +144,7 @@ The cluster doesn't exist. Create it using the methods above.
 
 **Symptom:**
 ```yaml
-Error: github-actions-staging does not have permission to access cluster
+Error: github-actions-preview does not have permission to access cluster
 ```
 
 **Solution:**
@@ -152,15 +152,15 @@ Verify the service account has the `container.developer` role:
 ```bash
 gcloud projects get-iam-policy vishnu-sandbox-20250310 \
   --flatten="bindings[].members" \
-  --filter="bindings.members:github-actions-staging*"
+  --filter="bindings.members:github-actions-preview*"
 ```
 ### Error: Artifact Registry repository not found
 
 **Solution:**
 Create the Artifact Registry repositories:
 ```bash
-# Staging
-gcloud artifacts repositories create mcp-staging \
+# Preview
+gcloud artifacts repositories create mcp-preview \
   --repository-format=docker \
   --location=us-central1 \
   --project=vishnu-sandbox-20250310
@@ -177,8 +177,8 @@ gcloud artifacts repositories create mcp-production \
 The deployment workflows check repository variables to determine if auto-deploy is enabled:
 
 ```bash
-# Enable staging auto-deploy
-gh variable set ENABLE_STAGING_AUTODEPLOY --body "true"
+# Enable preview auto-deploy
+gh variable set ENABLE_PREVIEW_AUTODEPLOY --body "true"
 
 # Enable dev auto-deploy
 gh variable set ENABLE_DEV_AUTODEPLOY --body "true"
@@ -202,4 +202,4 @@ gh variable list
 - Terraform module: ✅ Fixed and validated
 - Service accounts: ✅ Created and configured
 - Auto-deploy variables: ✅ Set
-- GKE clusters: ❌ Need to be created
+- GKE clusters: ✅ Created (preview-mcp-server-langgraph-gke)

--- a/docs/development/naming-conventions.mdx
+++ b/docs/development/naming-conventions.mdx
@@ -44,19 +44,19 @@ Due to GCP character limits on certain resources, we use a **dual-prefix approac
 | Environment | Abbreviation | Use Case |
 |-------------|-------------|----------|
 | Development | `dev` | Local development, testing, CI/CD validation |
-| Staging | `staging` | Pre-production testing, integration validation |
+| Preview | `preview` | Pre-production testing, integration validation |
 | Production | `production` | Live production workloads |
 
 ### Resource Types
 
 | Resource | Suffix | Example |
 |----------|--------|---------|
-| GKE Cluster | `-gke` | `staging-mcp-server-langgraph-gke` |
-| EKS Cluster | `-eks` | `staging-mcp-server-langgraph-eks` |
-| AKS Cluster | `-aks` | `staging-mcp-server-langgraph-aks` |
-| Namespace | *(none)* | `staging-mcp-server-langgraph` |
-| Deployment | *(none)* | `staging-mcp-server-langgraph` |
-| Service | *(none)* | `staging-mcp-server-langgraph` |
+| GKE Cluster | `-gke` | `preview-mcp-server-langgraph-gke` |
+| EKS Cluster | `-eks` | `preview-mcp-server-langgraph-eks` |
+| AKS Cluster | `-aks` | `preview-mcp-server-langgraph-aks` |
+| Namespace | *(none)* | `preview-mcp-server-langgraph` |
+| Deployment | *(none)* | `preview-mcp-server-langgraph` |
+| Service | *(none)* | `preview-mcp-server-langgraph` |
 
 ---
 
@@ -67,21 +67,21 @@ Due to GCP character limits on certain resources, we use a **dual-prefix approac
 #### Cluster Names
 ```yaml
 Development:  dev-mcp-server-langgraph-gke
-Staging:      staging-mcp-server-langgraph-gke
+Preview:      preview-mcp-server-langgraph-gke
 Production:   production-mcp-server-langgraph-gke
 ```
 
 #### Namespaces
 ```yaml
 Development:  dev-mcp-server-langgraph
-Staging:      staging-mcp-server-langgraph
+Preview:      preview-mcp-server-langgraph
 Production:   production-mcp-server-langgraph
 ```
 
 #### Deployments (with Kustomize namePrefix)
 ```yaml
 Development:  dev-mcp-server-langgraph
-Staging:      staging-mcp-server-langgraph
+Preview:      preview-mcp-server-langgraph
 Production:   production-mcp-server-langgraph
 ```
 
@@ -96,14 +96,14 @@ Headless:     {env}-mcp-server-langgraph-headless
 
 | Resource | Pattern | Example |
 |----------|---------|---------|
-| VPC | `{short_prefix}-vpc` | `staging-mcp-slg-vpc` |
-| Subnet | `{short_prefix}-{purpose}-subnet` | `staging-mcp-slg-nodes-us-central1` |
-| Cloud SQL | `{short_prefix}-postgres` | `staging-mcp-slg-postgres` |
-| Memorystore | `{short_prefix}-redis` | `staging-mcp-slg-redis` |
-| Service Account | `{short_prefix}-{role}-sa` | `staging-mcp-slg-app-sa` |
-| Artifact Registry | `mcp-{env}` | `mcp-staging`, `mcp-production` |
+| VPC | `{short_prefix}-vpc` | `preview-mcp-slg-vpc` |
+| Subnet | `{short_prefix}-{purpose}-subnet` | `preview-mcp-slg-nodes-us-central1` |
+| Cloud SQL | `{short_prefix}-postgres` | `preview-mcp-slg-postgres` |
+| Memorystore | `{short_prefix}-redis` | `preview-mcp-slg-redis` |
+| Service Account | `{short_prefix}-{role}-sa` | `preview-mcp-slg-app-sa` |
+| Artifact Registry | `mcp-{env}` | `mcp-preview`, `mcp-production` |
 
-**Note**: Short prefix = `{env}-mcp-slg` (e.g., `staging-mcp-slg`, `production-mcp-slg`, `dev-mcp-slg`)
+**Note**: Short prefix = `{env}-mcp-slg` (e.g., `preview-mcp-slg`, `production-mcp-slg`, `dev-mcp-slg`)
 
 ---
 
@@ -112,7 +112,7 @@ Headless:     {env}-mcp-server-langgraph-headless
 #### Cluster Names
 ```yaml
 Development:  dev-mcp-server-langgraph-eks
-Staging:      staging-mcp-server-langgraph-eks
+Preview:      preview-mcp-server-langgraph-eks
 Production:   production-mcp-server-langgraph-eks
 ```
 
@@ -120,7 +120,7 @@ Production:   production-mcp-server-langgraph-eks
 ```yaml
 (Same as GKE - platform-agnostic)
 Development:  dev-mcp-server-langgraph
-Staging:      staging-mcp-server-langgraph
+Preview:      preview-mcp-server-langgraph
 Production:   production-mcp-server-langgraph
 ```
 
@@ -128,11 +128,11 @@ Production:   production-mcp-server-langgraph
 
 | Resource | Pattern | Example |
 |----------|---------|---------|
-| VPC | `{name_prefix}-vpc` | `staging-mcp-server-langgraph-vpc` |
-| Subnet | `{name_prefix}-{az}-{type}` | `staging-mcp-server-langgraph-us-east-1a-private` |
-| RDS Instance | `{name_prefix}-db` | `staging-mcp-server-langgraph-db` |
-| ElastiCache | `{name_prefix}-redis` | `staging-mcp-server-langgraph-redis` |
-| IAM Role | `{cluster_name}-{purpose}` | `staging-mcp-server-langgraph-eks-cluster-role` |
+| VPC | `{name_prefix}-vpc` | `preview-mcp-server-langgraph-vpc` |
+| Subnet | `{name_prefix}-{az}-{type}` | `preview-mcp-server-langgraph-us-east-1a-private` |
+| RDS Instance | `{name_prefix}-db` | `preview-mcp-server-langgraph-db` |
+| ElastiCache | `{name_prefix}-redis` | `preview-mcp-server-langgraph-redis` |
+| IAM Role | `{cluster_name}-{purpose}` | `preview-mcp-server-langgraph-eks-cluster-role` |
 | ECR Repository | `mcp-server-langgraph` | *(environment in tags)* |
 
 ---
@@ -142,7 +142,7 @@ Production:   production-mcp-server-langgraph
 #### Cluster Names
 ```yaml
 Development:  dev-mcp-server-langgraph-aks
-Staging:      staging-mcp-server-langgraph-aks
+Preview:      preview-mcp-server-langgraph-aks
 Production:   production-mcp-server-langgraph-aks
 ```
 
@@ -150,7 +150,7 @@ Production:   production-mcp-server-langgraph-aks
 ```yaml
 (Same as GKE/EKS - platform-agnostic)
 Development:  dev-mcp-server-langgraph
-Staging:      staging-mcp-server-langgraph
+Preview:      preview-mcp-server-langgraph
 Production:   production-mcp-server-langgraph
 ```
 
@@ -158,10 +158,10 @@ Production:   production-mcp-server-langgraph
 
 | Resource | Pattern | Example |
 |----------|---------|---------|
-| Resource Group | `{name_prefix}-rg` | `staging-mcp-server-langgraph-rg` |
-| Virtual Network | `{name_prefix}-vnet` | `staging-mcp-server-langgraph-vnet` |
-| PostgreSQL | `{name_prefix}-db` | `staging-mcp-server-langgraph-db` |
-| Redis Cache | `{name_prefix}-redis` | `staging-mcp-server-langgraph-redis` |
+| Resource Group | `{name_prefix}-rg` | `preview-mcp-server-langgraph-rg` |
+| Virtual Network | `{name_prefix}-vnet` | `preview-mcp-server-langgraph-vnet` |
+| PostgreSQL | `{name_prefix}-db` | `preview-mcp-server-langgraph-db` |
+| Redis Cache | `{name_prefix}-redis` | `preview-mcp-server-langgraph-redis` |
 
 ---
 
@@ -180,9 +180,9 @@ Development:
   namespace: dev-mcp-server-langgraph
   namePrefix: dev-
 
-Staging (GKE):
-  namespace: staging-mcp-server-langgraph
-  namePrefix: staging-
+Preview (GKE):
+  namespace: preview-mcp-server-langgraph
+  namePrefix: preview-
 
 Production (GKE):
   namespace: production-mcp-server-langgraph
@@ -195,10 +195,10 @@ With `namePrefix` applied:
 
 | Base Name | Environment | Generated Name |
 |-----------|-------------|----------------|
-| `mcp-server-langgraph` (Deployment) | staging | `staging-mcp-server-langgraph` |
-| `mcp-server-langgraph` (Service) | staging | `staging-mcp-server-langgraph` |
-| `mcp-server-langgraph-config` (ConfigMap) | staging | `staging-mcp-server-langgraph-config` |
-| `mcp-server-langgraph-secrets` (Secret) | staging | `staging-mcp-server-langgraph-secrets` |
+| `mcp-server-langgraph` (Deployment) | preview | `preview-mcp-server-langgraph` |
+| `mcp-server-langgraph` (Service) | preview | `preview-mcp-server-langgraph` |
+| `mcp-server-langgraph-config` (ConfigMap) | preview | `preview-mcp-server-langgraph-config` |
+| `mcp-server-langgraph-secrets` (Secret) | preview | `preview-mcp-server-langgraph-secrets` |
 
 ---
 
@@ -216,7 +216,7 @@ ghcr.io/vishnu2kmohan/mcp-server-langgraph
 Pattern: {region}-docker.pkg.dev/{project-id}/mcp-{env}/{image-name}
 
 Development:  ghcr.io/vishnu2kmohan/mcp-server-langgraph
-Staging:      us-central1-docker.pkg.dev/vishnu-sandbox-20250310/mcp-staging/mcp-server-langgraph
+Preview:      us-central1-docker.pkg.dev/vishnu-sandbox-20250310/mcp-preview/mcp-server-langgraph
 Production:   us-central1-docker.pkg.dev/PROJECT_ID/mcp-production/mcp-server-langgraph
 ```
 
@@ -231,7 +231,7 @@ All Environments: mcp-server-langgraph (environment in tags)
 
 ```yaml
 Development:  2.8.0-dev, dev-latest, dev-{sha}
-Staging:      2.8.0-staging, staging-latest, staging-{sha}
+Preview:      2.8.0-preview, preview-latest, preview-{sha}
 Production:   2.8.0, latest, {sha}
 ```
 
@@ -244,21 +244,21 @@ Production:   2.8.0, latest, {sha}
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GKE_CLUSTER` | `dev-mcp-server-langgraph-gke` | Development GKE cluster |
-| `GKE_STAGING_CLUSTER` | `staging-mcp-server-langgraph-gke` | Staging GKE cluster |
+| `GKE_PREVIEW_CLUSTER` | `preview-mcp-server-langgraph-gke` | Preview GKE cluster |
 | `GKE_PROD_CLUSTER` | `production-mcp-server-langgraph-gke` | Production GKE cluster |
 
 ### Namespace Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `STAGING_NAMESPACE` | `staging-mcp-server-langgraph` | Staging namespace |
+| `PREVIEW_NAMESPACE` | `preview-mcp-server-langgraph` | Preview namespace |
 | `PRODUCTION_NAMESPACE` | `production-mcp-server-langgraph` | Production namespace |
 
 ### Deployment Names
 
 | Variable | Value | Description |
 |----------|-------|-------------|
-| `DEPLOYMENT_NAME` (staging) | `staging-mcp-server-langgraph` | Staging deployment |
+| `DEPLOYMENT_NAME` (preview) | `preview-mcp-server-langgraph` | Preview deployment |
 | `DEPLOYMENT_NAME` (production) | `production-mcp-server-langgraph` | Production deployment |
 
 ---
@@ -269,8 +269,8 @@ Production:   2.8.0, latest, {sha}
 
 ```hcl
 locals {
-  # GCP Staging
-  name_prefix  = "staging-mcp-server-langgraph"
+  # GCP Preview
+  name_prefix  = "preview-mcp-server-langgraph"
   cluster_name = "${local.name_prefix}-gke"
 
   # GCP Production
@@ -285,8 +285,8 @@ locals {
   name_prefix  = "dev-mcp-server-langgraph"
   cluster_name = "${local.name_prefix}-eks"
 
-  # AWS Staging
-  name_prefix  = "staging-mcp-server-langgraph"
+  # AWS Preview
+  name_prefix  = "preview-mcp-server-langgraph"
   cluster_name = "${local.name_prefix}-eks"
 }
 ```
@@ -298,10 +298,10 @@ locals {
 ### Environment Variables
 
 ```bash
-# GCP Staging
-CLUSTER_NAME="staging-mcp-server-langgraph-gke"
-NAMESPACE="staging-mcp-server-langgraph"
-SERVICE_NAME="staging-mcp-server-langgraph"
+# GCP Preview
+CLUSTER_NAME="preview-mcp-server-langgraph-gke"
+NAMESPACE="preview-mcp-server-langgraph"
+SERVICE_NAME="preview-mcp-server-langgraph"
 
 # GCP Production
 CLUSTER_NAME="production-mcp-server-langgraph-gke"
@@ -322,12 +322,13 @@ SERVICE_NAME="dev-mcp-server-langgraph"
 
 | Old Pattern | New Pattern | Status |
 |-------------|-------------|--------|
-| `mcp-staging-cluster` | `staging-mcp-server-langgraph-gke` | ❌ Deprecated |
+| `mcp-staging-cluster` | `preview-mcp-server-langgraph-gke` | ❌ Deprecated |
 | `mcp-prod-gke` | `production-mcp-server-langgraph-gke` | ❌ Deprecated |
-| `mcp-staging` | `staging-mcp-server-langgraph` | ❌ Deprecated |
+| `mcp-staging` | `preview-mcp-server-langgraph` | ❌ Deprecated |
 | `mcp-production` | `production-mcp-server-langgraph` | ❌ Deprecated |
-| `mcp-server-langgraph-staging` | `staging-mcp-server-langgraph` | ❌ Deprecated |
+| `mcp-server-langgraph-staging` | `preview-mcp-server-langgraph` | ❌ Deprecated |
 | `mcp-dev-cluster` | `dev-mcp-server-langgraph-gke` | ❌ Deprecated |
+| `staging-*` | `preview-*` | ❌ Deprecated (use preview-) |
 
 ### Migration Status
 

--- a/docs/security/gke-preview-checklist.mdx
+++ b/docs/security/gke-preview-checklist.mdx
@@ -69,11 +69,11 @@ gcloud container clusters describe preview-mcp-server-langgraph-gke \
 **Verification:**
 ```bash
 ## List network policies
-kubectl get networkpolicies -n staging-mcp-server-langgraph
+kubectl get networkpolicies -n preview-mcp-server-langgraph
 
 ## Check specific policies
-kubectl describe networkpolicy default-deny-ingress -n staging-mcp-server-langgraph
-kubectl describe networkpolicy allow-egress -n staging-mcp-server-langgraph
+kubectl describe networkpolicy default-deny-ingress -n preview-mcp-server-langgraph
+kubectl describe networkpolicy allow-egress -n preview-mcp-server-langgraph
 ```
 
 #### Firewall Rules
@@ -83,8 +83,8 @@ kubectl describe networkpolicy allow-egress -n staging-mcp-server-langgraph
 
 **Verification:**
 ```bash
-## List firewall rules for staging VPC
-gcloud compute firewall-rules list --filter="network:staging-vpc"
+## List firewall rules for preview VPC
+gcloud compute firewall-rules list --filter="network:preview-vpc"
 ```
 
 ### Identity & Access Management (IAM)
@@ -99,11 +99,11 @@ gcloud compute firewall-rules list --filter="network:staging-vpc"
 ```bash
 ## Check service account IAM bindings
 gcloud iam service-accounts get-iam-policy \
-  mcp-staging-sa@vishnu-sandbox-20250310.iam.gserviceaccount.com
+  mcp-preview-sa@vishnu-sandbox-20250310.iam.gserviceaccount.com
 
 ## Verify no keys exist
 gcloud iam service-accounts keys list \
-  --iam-account=mcp-staging-sa@vishnu-sandbox-20250310.iam.gserviceaccount.com
+  --iam-account=mcp-preview-sa@vishnu-sandbox-20250310.iam.gserviceaccount.com
 ```
 #### Workload Identity
 - [ ] Kubernetes service account is annotated with GCP SA
@@ -113,13 +113,13 @@ gcloud iam service-accounts keys list \
 **Verification:**
 ```bash
 ## Check K8s service account annotation
-kubectl describe sa mcp-server-langgraph -n staging-mcp-server-langgraph | grep iam.gke.io
+kubectl describe sa mcp-server-langgraph -n preview-mcp-server-langgraph | grep iam.gke.io
 
 ## Test Workload Identity from pod
 kubectl run -it --rm test \
   --image=google/cloud-sdk:slim \
   --serviceaccount=mcp-server-langgraph \
-  --namespace=mcp-staging \
+  --namespace=preview-mcp-server-langgraph \
   -- gcloud auth list
 ```
 
@@ -151,11 +151,11 @@ gcloud iam workload-identity-pools providers describe github-provider \
 
 **Verification:**
 ```bash
-## List staging secrets
-gcloud secrets list --filter="name:staging-*"
+## List preview secrets
+gcloud secrets list --filter="name:preview-*"
 
 ## Verify permissions
-gcloud secrets get-iam-policy staging-jwt-secret
+gcloud secrets get-iam-policy preview-jwt-secret
 ```
 
 #### External Secrets Operator
@@ -170,10 +170,10 @@ gcloud secrets get-iam-policy staging-jwt-secret
 kubectl get pods -n external-secrets-system
 
 ## Check ExternalSecret status
-kubectl get externalsecret mcp-staging-secrets -n staging-mcp-server-langgraph
+kubectl get externalsecret mcp-preview-secrets -n preview-mcp-server-langgraph
 
 ## Verify secrets are synced
-kubectl get secret mcp-staging-secrets -n staging-mcp-server-langgraph
+kubectl get secret mcp-preview-secrets -n preview-mcp-server-langgraph
 ```
 ### Container Security
 
@@ -186,7 +186,7 @@ kubectl get secret mcp-staging-secrets -n staging-mcp-server-langgraph
 **Verification:**
 ```bash
 ## Check image source
-kubectl get deployment staging-mcp-server-langgraph -n staging-mcp-server-langgraph \
+kubectl get deployment preview-mcp-server-langgraph -n preview-mcp-server-langgraph \
   -o jsonpath='{.spec.template.spec.containers[0].image}'
 
 ## Check Binary Authorization policy
@@ -203,11 +203,11 @@ gcloud container binauthz policy export
 **Verification:**
 ```bash
 ## Check pod security context
-kubectl get pod -n staging-mcp-server-langgraph -o json | \
+kubectl get pod -n preview-mcp-server-langgraph -o json | \
   jq '.items[].spec.securityContext'
 
 ## Check for privileged containers
-kubectl get pods -n staging-mcp-server-langgraph -o json | \
+kubectl get pods -n preview-mcp-server-langgraph -o json | \
   jq '.items[].spec.containers[] | select(.securityContext.privileged == true)'
 ```
 #### Cloud SQL Proxy Sidecar
@@ -219,7 +219,7 @@ kubectl get pods -n staging-mcp-server-langgraph -o json | \
 **Verification:**
 ```bash
 ## Check Cloud SQL proxy container
-kubectl get pod -n staging-mcp-server-langgraph -o json | \
+kubectl get pod -n preview-mcp-server-langgraph -o json | \
   jq '.items[].spec.containers[] | select(.name == "cloud-sql-proxy")'
 ```
 
@@ -237,7 +237,7 @@ kubectl get pod -n staging-mcp-server-langgraph -o json | \
 kubectl cluster-info
 
 ## Check Cloud SQL instance encryption
-gcloud sql instances describe mcp-staging-postgres \
+gcloud sql instances describe mcp-preview-postgres \
   --format='value(diskEncryptionStatus.kmsKeyName)'
 ```
 
@@ -250,11 +250,11 @@ gcloud sql instances describe mcp-staging-postgres \
 **Verification:**
 ```bash
 ## Check Cloud SQL IP configuration
-gcloud sql instances describe mcp-staging-postgres \
+gcloud sql instances describe mcp-preview-postgres \
   --format='value(ipAddresses[])'
 
 ## Check backup configuration
-gcloud sql instances describe mcp-staging-postgres \
+gcloud sql instances describe mcp-preview-postgres \
   --format='value(settings.backupConfiguration)'
 ```
 
@@ -267,11 +267,11 @@ gcloud sql instances describe mcp-staging-postgres \
 **Verification:**
 ```bash
 ## Check Redis configuration
-gcloud redis instances describe mcp-staging-redis \
+gcloud redis instances describe mcp-preview-redis \
   --region=us-central1
 
 ## Verify AUTH is enabled
-gcloud redis instances describe mcp-staging-redis \
+gcloud redis instances describe mcp-preview-redis \
   --region=us-central1 \
   --format='value(authEnabled)'
 ```
@@ -321,7 +321,7 @@ gcloud alpha monitoring policies list
 **Verification:**
 ```bash
 ## This is configured in OTel collector, check collector logs
-kubectl logs -n staging-mcp-server-langgraph -l app=otel-collector
+kubectl logs -n preview-mcp-server-langgraph -l app=otel-collector
 ```
 
 ### Compliance & Governance
@@ -339,7 +339,7 @@ gcloud container clusters describe preview-mcp-server-langgraph-gke \
   --format='value(resourceLabels)'
 
 ## Check pods have labels
-kubectl get pods -n staging-mcp-server-langgraph --show-labels
+kubectl get pods -n preview-mcp-server-langgraph --show-labels
 ```
 #### Resource Limits
 - [ ] All containers have resource requests
@@ -350,14 +350,14 @@ kubectl get pods -n staging-mcp-server-langgraph --show-labels
 **Verification:**
 ```bash
 ## Check container resources
-kubectl get pods -n staging-mcp-server-langgraph -o json | \
+kubectl get pods -n preview-mcp-server-langgraph -o json | \
   jq '.items[].spec.containers[] | {name: .name, resources: .resources}'
 
 ## Check ResourceQuota
-kubectl get resourcequota -n staging-mcp-server-langgraph
+kubectl get resourcequota -n preview-mcp-server-langgraph
 
 ## Check LimitRange
-kubectl get limitrange -n staging-mcp-server-langgraph
+kubectl get limitrange -n preview-mcp-server-langgraph
 ```
 
 #### Backup & Disaster Recovery
@@ -369,11 +369,11 @@ kubectl get limitrange -n staging-mcp-server-langgraph
 **Verification:**
 ```bash
 ## Check backup configuration
-gcloud sql instances describe mcp-staging-postgres \
+gcloud sql instances describe mcp-preview-postgres \
   --format='value(settings.backupConfiguration.enabled)'
 
 ## List backups
-gcloud sql backups list --instance=mcp-staging-postgres
+gcloud sql backups list --instance=mcp-preview-postgres
 ```
 ### GitHub Actions Security
 
@@ -386,7 +386,7 @@ gcloud sql backups list --instance=mcp-staging-postgres
 
 **Verification:**
 - Review `.github/workflows/deploy-preview-gke.yaml`
-- Check GitHub repository settings → Environments → staging
+- Check GitHub repository settings → Environments → preview
 
 #### Deployment Validation
 - [ ] Smoke tests run post-deployment
@@ -398,7 +398,7 @@ gcloud sql backups list --instance=mcp-staging-postgres
 ```bash
 ## Check recent deployments in Cloud Console
 gcloud container clusters get-credentials preview-mcp-server-langgraph-gke --region=us-central1
-kubectl rollout history deployment/staging-mcp-server-langgraph -n staging-mcp-server-langgraph
+kubectl rollout history deployment/preview-mcp-server-langgraph -n preview-mcp-server-langgraph
 ```
 
 ### Security Scanning
@@ -416,7 +416,7 @@ gcloud services enable containeranalysis.googleapis.com
 
 ## Scan image
 gcloud artifacts docker images scan \
-  us-central1-docker.pkg.dev/vishnu-sandbox-20250310/mcp-staging/agent:staging-latest
+  us-central1-docker.pkg.dev/vishnu-sandbox-20250310/mcp-preview/agent:preview-latest
 ```
 #### Security Auditing
 - [ ] Regular security audits scheduled
@@ -433,14 +433,14 @@ gcloud artifacts docker images scan \
 
 #### Rollback Procedures
 - [ ] Documented rollback procedure
-- [ ] Rollback tested in staging
+- [ ] Rollback tested in preview
 - [ ] Automatic rollback configured in CI/CD
 
 **Test Rollback:**
 ```bash
 ## Manual rollback test
-kubectl rollout undo deployment/staging-mcp-server-langgraph -n staging-mcp-server-langgraph
-kubectl rollout status deployment/staging-mcp-server-langgraph -n staging-mcp-server-langgraph
+kubectl rollout undo deployment/preview-mcp-server-langgraph -n preview-mcp-server-langgraph
+kubectl rollout status deployment/preview-mcp-server-langgraph -n preview-mcp-server-langgraph
 ```
 
 ---
@@ -453,7 +453,7 @@ kubectl rollout status deployment/staging-mcp-server-langgraph -n staging-mcp-se
 - **90-100% complete**: Excellent - Production-ready security posture
 - **80-89% complete**: Good - Minor improvements needed
 - **70-79% complete**: Fair - Significant gaps exist
-- **&lt;70% complete**: Poor - Not ready for production-like staging
+- **&lt;70% complete**: Poor - Not ready for production-like preview
 
 ### Next Steps
 


### PR DESCRIPTION
## Summary

- Complete documentation updates for the staging → preview environment rename
- Update security checklist, naming conventions, and GKE cluster requirements docs
- Add Kustomize namePrefix gotchas memory file documenting the secretKeyRef issue

## Changes

### Documentation Updates
- **docs/security/gke-preview-checklist.mdx** - Update 20+ kubectl/gcloud commands with preview namespace and resource names
- **docs/development/naming-conventions.mdx** - Update environments table, resource naming examples, and deprecation list
- **docs/deployment/infrastructure/gke-cluster-requirements.mdx** - Rename staging cluster section to preview cluster

### New Memory File
- **.claude/memory/kustomize-nameprefix-gotchas.md** - Document critical Kustomize namePrefix gotcha where `secretKeyRef.name` references are not automatically updated

## Test plan

- [ ] Docs build without errors
- [ ] No remaining staging-gke references in updated files
- [ ] Memory file correctly documents the namePrefix issue

## Related

- Follows up on PR #140 (staging → preview rename)
- Completes Phase 7 of the staging-to-preview rename plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)